### PR TITLE
Added .bowerrc to set output directory

### DIFF
--- a/app/templates/.bowerrc
+++ b/app/templates/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
My Bower defaults to `./src/bower_components` as output directory for some reason, so by adding `.bowerrc` I'm fine...